### PR TITLE
fix/scraper_download_docstrings

### DIFF
--- a/ktnetscraper/scraper.py
+++ b/ktnetscraper/scraper.py
@@ -452,7 +452,7 @@ class Scraper(object):
         Returns
         -------
         bytes
-            教材データか教材データを格納したリストを返す。
+            教材ファイルのデータ
         '''
         url = type_checked(url, str)
         return self.request(method='GET', url=url).content


### PR DESCRIPTION
Scrapaer.downloadメソッドのdocstringsに記述されている返り値の説明を修正。